### PR TITLE
Byte, not char, output to allow arbitrary UTF-8 to be constructed byte-by-byte 

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -41,7 +41,7 @@ impl<'a> Interpreter<'a> {
                     }
                 }
                 Command::Output => {
-                    let _ = write!(self.output, "{}", self.arr[self.pointer] as char);
+                    let _ = self.output.write(&[self.arr[self.pointer]]);
                 }
                 Command::Input => {
                     let mut buffer: [u8; 1] = [0];


### PR DESCRIPTION
This change will allow arbitrary binary output (i.e. files)  to be generated accurately from bf code. 

`char` output prevents arbitrary multi-byte UTF-8 characters from being constructed, and limits the range of output to the first 255 Unicode code points, and will sometimes cause multiple bytes to be output on one `.`, which is probably not intended.

Byte based output is how the original bfc functioned.

**Testing:**
(Using Bash on Ubuntu 22.04 -- I hope Windows can handle bytes / chars the same way...)

Using the following bf code to test:

    >++++[>----<-]>.<-[->--[--<]>]>+++.+++++.+++++++++++.

With this change, the output is four bytes / one UTF-8 character:
```
bf <(echo ">++++[>----<-]>.<-[->--[--<]>]>+++.+++++.+++++++++++.")
🤯
```
and hex view using `xxd`:
```
bf <(echo ">++++[>----<-]>.<-[->--[--<]>]>+++.+++++.+++++++++++.") | xxd
00000000: f09f a4af 
```

Before, the output was four UTF-8 characters (8 bytes)
```
bf <(echo ">++++[>----<-]>.<-[->--[--<]>]>+++.+++++.+++++++++++.")
ð
```

and

```
bf <(echo ">++++[>----<-]>.<-[->--[--<]>]>+++.+++++.+++++++++++.") | xxd
00000000: c3b0 c29f c2a4 c2af                      ........
```

I have not tested this thoroughly with input, or looked into whether the input command `,` makes sense in terms of Rust `char` or bytes.... 
